### PR TITLE
Corrects a couple of bugs

### DIFF
--- a/unorphanize.jquery.js
+++ b/unorphanize.jquery.js
@@ -13,31 +13,30 @@
         return $(this).each( function() {
 
             var $el = $(this), htmlEls = [],
+            spaceRegex = /\s+(\S+)$/gm, spaceReplace = '&nbsp;$1',
             text, els, i, lastIndex, lngth, replaceRegex;
 
             // "text" is going to be our "goto-girl" for string manipulation
-            text = $el.html();
+            text = $el.html().trim();
 
             // grab any html tags like a,strong,em
             els = text.match(/<([A-Z][A-Z0-9]*)\b[^>]*>/gi);
             lngth = ( els !== null ) ? els.length : 0;
 
-            // each time we match a html element opening tag (eg: <a href="">), 
+            // each time we match a html element opening tag (eg: <a href="">),
             // save it into array and replace it with a placeholder like: "__n__";
             for( i = 0; i < lngth; i++ ) {
                 htmlEls.push( els[i] );
                 text = text.replace( els[i] , "__"+i+"__");
             }
 
-            // now we find the given number of gathered words, and then insert a 
+            // now we find the given number of gathered words, and then insert a
             // non-breaking-space (&nbsp;) in to the given number of spaces.
             for( i = 0; i < gather; i++ ) {
-                lastIndex = text.lastIndexOf(" ");
-                if( lastIndex > 0 ) {
-                    text = text.substring(0, lastIndex) + "&nbsp;" + text.substring(lastIndex + 1);
-                }
+                text = text.replace( spaceRegex , spaceReplace );
             }
-            // now we have put the non-breaking-spaces in, we must replace the 
+
+            // now we have put the non-breaking-spaces in, we must replace the
             // placeholders with the original html elements we stored earlier.
             for( i = 0; i < lngth; i++ ) {
                 replaceRegex = new RegExp("__"+i+"__");

--- a/unorphanize.jquery.min.js
+++ b/unorphanize.jquery.min.js
@@ -1,3 +1,3 @@
 /*! jquery-unorphanize - v1.0.1 - 2014-04-18
 * Copyright (c) 2014 Simon Goellner <simey.me@gmail.com>; Licensed  */
-!function(a){a.fn.unorphanize=function(b){return"number"!=typeof b&&(b=1),a(this).each(function(){var c,d,e,f,g,h,i=a(this),j=[];for(c=i.html(),d=c.match(/<([A-Z][A-Z0-9]*)\b[^>]*>/gi),g=null!==d?d.length:0,e=0;g>e;e++)j.push(d[e]),c=c.replace(d[e],"__"+e+"__");for(e=0;b>e;e++)f=c.lastIndexOf(" "),f>0&&(c=c.substring(0,f)+"&nbsp;"+c.substring(f+1));for(e=0;g>e;e++)h=new RegExp("__"+e+"__"),c=c.replace(h,j[e]);i.html(c)})}}(jQuery);
+!function(l){l.fn.unorphanize=function(i){return"number"!=typeof i&&(i=1),l(this).each(function(){var e,n,r,t,h,u=l(this),c=[],f=/\s+(\S+)$/gm;for(t=null!==(n=(e=u.html().trim()).match(/<([A-Z][A-Z0-9]*)\b[^>]*>/gi))?n.length:0,r=0;r<t;r++)c.push(n[r]),e=e.replace(n[r],"__"+r+"__");for(r=0;r<i;r++)e=e.replace(f,"&nbsp;$1");for(r=0;r<t;r++)h=new RegExp("__"+r+"__"),e=e.replace(h,c[r]);u.html(e)})}}(jQuery);


### PR DESCRIPTION
- **Trims string**
_as trailing spaces would confuse the replacement function_.
- **Implements a Regular Expression based replacement of spaces**
_to prevent repeated spaces being replaced individually_.

`<p>The quick brown fox jumped over the lazy dog </p>` used to be converted to `<p>The quick brown fox jumped over the lazy dog&nbsp;</p>`

Line 20 fixes this by trimming the html content of the element.

`<p>The quick brown fox jumped over the lazy  dog</p>` used to be converted to `<p>The quick brown fox jumped over the lazy &nbsp;dog</p>`

Line 42 fixes this by using a regular expression which matches one or more whitespace characters.